### PR TITLE
docs(readme): add HACS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Home Assistant will restart automatically and the integration is ready to config
    reach `/config` without a terminal is via the **Samba share** app (Settings → Apps → Samba share). The **Terminal & SSH** app also works.
 3. Restart Home Assistant.
 
+### Via HACS
+
+1. Install [HACS](https://hacs.xyz) if you don't have it yet.
+2. In HACS, open the **⋮** menu (top right) and select **Custom repositories**.
+3. Add `https://github.com/Solar-Assistant/ha_solar_assistant` with category **Integration**.
+4. Find **SolarAssistant** in HACS, click **Download**, then restart Home Assistant.
+
+> **Note**: SolarAssistant is not on the HACS default list yet, so adding the custom repository URL above is required.
+
 ## Updating
 
 ### Via Add-on


### PR DESCRIPTION
## What

Adds a **Via HACS** option to the Installation section of the README, right after the existing **Manual** method.

## Why

HACS is the standard way to install custom integrations for Home Assistant users who are not on Home Assistant OS (Core, Container, Supervised). The integration ships a valid `hacs.json`, so it installs cleanly via HACS — it just isn't on the HACS default list yet, so the custom repository step is documented.

## Changes

- `README.md` only: new `### Via HACS` subsection with steps to add the repo as a custom HACS repository (category: Integration) and install.

Closes nothing; docs-only change.